### PR TITLE
Changed np.float to builtin float.

### DIFF
--- a/pyACS/acs.py
+++ b/pyACS/acs.py
@@ -292,7 +292,10 @@ class ACS:
                         self.delta_t_a = np.empty((self.output_wavelength, n))
                 elif l[0] == '\t':
                     # Temperatures
-                    self.t = np.array(l.split(';')[0].strip().split('\t')).astype(np.float)
+                    try:  # Try with numpy float attribute (numpy version < 1.20)
+                        self.t = np.array(l.split(';')[0].strip().split('\t')).astype(np.float)
+                    except: # If AttributeError, then default to builtin float (numpy version >= 1.20)
+                        self.t = np.array(l.split(';')[0].strip().split('\t')).astype(float)
                 elif l[0] == 'C':
                     foo = l.split('\t\t')
                     # Wavelength

--- a/pyACS/acs.py
+++ b/pyACS/acs.py
@@ -292,10 +292,7 @@ class ACS:
                         self.delta_t_a = np.empty((self.output_wavelength, n))
                 elif l[0] == '\t':
                     # Temperatures
-                    try:  # Try with numpy float attribute (numpy version < 1.20)
-                        self.t = np.array(l.split(';')[0].strip().split('\t')).astype(np.float)
-                    except: # If AttributeError, then default to builtin float (numpy version >= 1.20)
-                        self.t = np.array(l.split(';')[0].strip().split('\t')).astype(float)
+                    self.t = np.array(l.split(';')[0].strip().split('\t')).astype(float)
                 elif l[0] == 'C':
                     foo = l.split('\t\t')
                     # Wavelength


### PR DESCRIPTION
This should solve issues described in Issue #2.

In the try statement, np.float is attempted, which should support numpy versions before 1.20. 
If that fails, the except statement will use the float builtin instead, which should support numpy versions greater than 1.20 to the current release (1.24). 